### PR TITLE
GHOSTSW-16: ITC tabs now shown on base component.

### DIFF
--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcPanel.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/editor/seq/ItcPanel.scala
@@ -176,6 +176,7 @@ class ItcImagingPanel(val owner: EdIteratorFolder) extends ItcPanel {
   def visibleFor(t: SPComponentType): Boolean = t match {
     case SPComponentType.INSTRUMENT_ACQCAM      => true
     case SPComponentType.INSTRUMENT_FLAMINGOS2  => true
+    case SPComponentType.INSTRUMENT_GHOST       => true
     case SPComponentType.INSTRUMENT_GMOS        => true
     case SPComponentType.INSTRUMENT_GMOSSOUTH   => true
     case SPComponentType.INSTRUMENT_GSAOI       => true
@@ -210,6 +211,7 @@ class ItcSpectroscopyPanel(val owner: EdIteratorFolder) extends ItcPanel {
   /** True for all instruments which support ITC calculations for spectroscopy. */
   def visibleFor(t: SPComponentType): Boolean = t match {
     case SPComponentType.INSTRUMENT_FLAMINGOS2  => true
+    case SPComponentType.INSTRUMENT_GHOST       => true
     case SPComponentType.INSTRUMENT_GMOS        => true
     case SPComponentType.INSTRUMENT_GMOSSOUTH   => true
     case SPComponentType.INSTRUMENT_GNIRS       => true


### PR DESCRIPTION
![Screen Shot 2019-12-26 at 9 52 25 AM](https://user-images.githubusercontent.com/8795653/71476763-78fb5800-27c5-11ea-87b9-06a744379c80.png)

I don't think we need to do anything else for this: with multiple targets, the multiple targets appear in the drop-down Target menu, and nothing appears (as appropriate) for sky positions.